### PR TITLE
Add '.git' to all GitHub URLs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,8 @@ let package = Package(
         .library(name: "CombineWamp", targets: ["CombineWamp"])
     ],
     dependencies: [
-        .package(url: "https://github.com/teufelaudio/CombineWebSocket", .branch("master")),
-        .package(url: "https://github.com/teufelaudio/FoundationExtensions", .branch("master"))
+        .package(url: "https://github.com/teufelaudio/CombineWebSocket.git", .branch("master")),
+        .package(url: "https://github.com/teufelaudio/FoundationExtensions.git", .branch("master"))
     ],
     targets: [
         .target(name: "CombineWamp", dependencies: ["CombineWebSocket", "FoundationExtensions"]),


### PR DESCRIPTION
Without these, <https://github.com/teufelaudio/SwiftPackageAcknowledgement> does not know how to fetch the license from these dependencies. With '.git' added, everything is working as expected.