### PR TITLE
Make URI init with unverified params public

### DIFF
--- a/Sources/CombineWamp/Model/URI.swift
+++ b/Sources/CombineWamp/Model/URI.swift
@@ -39,7 +39,7 @@ public struct URI: Equatable, RawRepresentable, CustomStringConvertible, Lossles
         self.isWildcard = wildcard.contains("..") || wildcard.hasPrefix(".") || wildcard.hasSuffix(".")
     }
 
-    init(unverified: String, isWildcard: Bool = false) {
+    public init(unverified: String, isWildcard: Bool = false) {
         self.rawValue = unverified
         self.isWildcard = isWildcard
     }


### PR DESCRIPTION
Hello, please check my PR. 
There is recommendation base on https://wamp-proto.org/wamp_latest_ietf.html#name-uris how the URI should looks like.
Solution implemented in CombineWamp is based on Strict URIs but there is also option to do it Relaxed/Loose URIs
One of possible solution is to keep validation on developers to decide. 
